### PR TITLE
Make id optional while continuing to use it for validation when provided

### DIFF
--- a/src/app/arg.rs
+++ b/src/app/arg.rs
@@ -160,8 +160,8 @@ pub struct GetExportSubcommand {
     pub position: u64,
 
     /// The ID of the record to extract.
-    #[clap(long, required = true)]
-    pub id: String,
+    #[clap(long)]
+    pub id: Option<String>,
 
     /// Path for the output messages.
     #[clap(long, default_value = "-")]
@@ -196,8 +196,8 @@ pub struct GetExtractSubcommand {
     pub position: u64,
 
     /// The ID of the record to extract.
-    #[clap(long, required = true)]
-    pub id: String,
+    #[clap(long)]
+    pub id: Option<String>,
 
     /// Path for the output file.
     #[clap(long, default_value = "-")]

--- a/src/app/get.rs
+++ b/src/app/get.rs
@@ -55,7 +55,7 @@ fn export(args: &GetExportSubcommand) -> anyhow::Result<()> {
 
     let record_id = header.fields.get_or_default("WARC-Record-ID");
 
-    if record_id != args.id {
+    if !args.id.as_ref().is_none_or(|id| id == record_id) {
         return Err(ProtocolError::new(ProtocolErrorKind::NotFound).into());
     }
 
@@ -123,7 +123,7 @@ fn extract(args: &GetExtractSubcommand) -> anyhow::Result<()> {
 
     let record_id = header.fields.get_or_default("WARC-Record-ID");
 
-    if record_id != args.id {
+    if !args.id.as_ref().is_none_or(|id| id == record_id) {
         return Err(ProtocolError::new(ProtocolErrorKind::NotFound).into());
     }
 


### PR DESCRIPTION
**Summary:**

Makes providing an id for get extract and get export optional; When provided the id is still used for validating the warc item

**Related issues:**

[Discussion:: Why is id required for get export and get extract?](https://github.com/chfoo/warcat-rs/discussions/6)

**Other:**

I've tested that get extract works when no id is provide & when the correct/valid id is provided & that it fails when provided with an incorrect/invalid id. 

Let me know if you'd like me to run more tests and if there's any documentation or unit tests that I should update